### PR TITLE
add redshift negate lookup dialect

### DIFF
--- a/lookup_extensions/lookups.py
+++ b/lookup_extensions/lookups.py
@@ -69,6 +69,7 @@ VENDOR_DIALECT = {
         },
     },
 }
+VENDOR_DIALECT['redshift'] = VENDOR_DIALECT['postgresql']
 
 
 class NeLookup(Lookup):

--- a/runtests.py
+++ b/runtests.py
@@ -21,6 +21,8 @@ def runtests():
 
     TestRunner = get_runner(settings)
     test_runner = TestRunner(verbosity=2, interactive=False)
+    if os.environ.get('TEST_WITH_REDSHIFT', None) == 'yes':
+        test_runner.keepdb = True
     failures = test_runner.run_tests(['tests'])
     sys.exit(bool(failures))
 

--- a/tests/test_lookup_extensions.py
+++ b/tests/test_lookup_extensions.py
@@ -828,7 +828,8 @@ class NeLookupMySqlTest(TestCase):
 
 
 @unittest.skipUnless(
-    'db_postgresql' in connections and connections['db_postgresql'].vendor == 'postgresql',
+    ('db_postgresql' in connections and connections['db_postgresql'].vendor == 'postgresql' or \
+     'db_postgresql' in connections and connections['db_postgresql'].vendor == 'redshift'),
     'postgresql tests',
 )
 class NeLookupPostgreSQLTest(TestCase):
@@ -839,9 +840,8 @@ class NeLookupPostgreSQLTest(TestCase):
         self.compiler = self.query.get_compiler(connection=self.using_connection)
         self.field = ModelPostgreSQLA._meta.get_field('name')
         self.other_field = ModelPostgreSQLB._meta.get_field('name')
-        ModelPostgreSQLA.objects.create(name='test name')
-        ModelPostgreSQLA.objects.create(name='test name1')
-
+        ModelPostgreSQLA.objects.create(id=1, name='test name')
+        ModelPostgreSQLA.objects.create(id=2, name='test name1')
     def tearDown(self):
         super(NeLookupPostgreSQLTest, self).tearDown()
         ModelPostgreSQLA.objects.all().delete()

--- a/tests/test_lookup_extensions.py
+++ b/tests/test_lookup_extensions.py
@@ -828,7 +828,7 @@ class NeLookupMySqlTest(TestCase):
 
 
 @unittest.skipUnless(
-    ('db_postgresql' in connections and connections['db_postgresql'].vendor == 'postgresql' or \
+    ('db_postgresql' in connections and connections['db_postgresql'].vendor == 'postgresql' or
      'db_postgresql' in connections and connections['db_postgresql'].vendor == 'redshift'),
     'postgresql tests',
 )
@@ -842,6 +842,7 @@ class NeLookupPostgreSQLTest(TestCase):
         self.other_field = ModelPostgreSQLB._meta.get_field('name')
         ModelPostgreSQLA.objects.create(id=1, name='test name')
         ModelPostgreSQLA.objects.create(id=2, name='test name1')
+
     def tearDown(self):
         super(NeLookupPostgreSQLTest, self).tearDown()
         ModelPostgreSQLA.objects.all().delete()

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -1,3 +1,4 @@
+import os
 
 
 class TestRouter(object):
@@ -38,9 +39,8 @@ class TestRouter(object):
             return db == 'default'
         elif app_label == 'app_mysql':
             return db == 'db_mysql'
-        elif app_label == 'app_postgresql':
-            return db == 'db_postgresql'
-
-        if app_label == 'auth':
-            return db == 'auth_db'
+        elif app_label == 'app_postgresql' and db == 'db_postgresql':
+            if os.environ.get('TEST_WITH_REDSHIFT', None) == 'yes':
+                return False
+            return True
         return None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -71,5 +71,17 @@ if os.environ.get('TEST_WITH_POSTGRESQL', None) == 'yes':
             'NAME': 'test_db_postgresql_' + os.getenv('TRAVIS_JOB_NUMBER', "").replace('.', '_')
         }
     }
+elif os.environ.get('TEST_WITH_REDSHIFT', None) == 'yes':
+    DATABASES['db_postgresql'] = {
+        'NAME': 'testredshift',
+        'ENGINE': 'django_redshift_backend',
+        'USER': '<REDSHIFT_USER>',
+        'PASSWORD': '<REDSHIFT_PASSWORD>',
+        'HOST': '<REDSHIFT_HOST>',
+        'PORT': '5439',
+        'TEST': {
+            'NAME': 'testredshift'
+        }
+    }
 
 DATABASE_ROUTERS = ['tests.test_routers.TestRouter']

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,8 +4,6 @@ import os
 
 SECRET_KEY = 'fake-key'
 INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
     'lookup_extensions',
     'tests',
     'tests.app_default',


### PR DESCRIPTION
- redshift's negate query is compatible with PostgreSQL
- don't run migrate with redshift test.
    - need create table before test with redshit
        ```
        create table app_postgresql_modelpostgresqla
        (
          id INTEGER primary key,
          name varchar(128) not null
        );
        create table app_postgresql_modelpostgresqlb
        (
          id INTEGER primary key,
          name varchar(128) not null
        );
        ```