### PR TITLE
Migrate to complement

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,16 +2,12 @@
 History
 =======
 
-0.4.0
------
-
-- Migrate to `complement` from `exists` and `neexists`
-
 0.2.0
 -----
 
 - Add support for Django 2.1
 - Add support for Python 3.7
+- Migrate to `complement` from `exists` and `neexists`
 
 0.1.0
 -----

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.4.0
+-----
+
+- Migrate to `complement` from `exists` and `neexists`
+
 0.2.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -102,11 +102,10 @@ neexact is negate exact, neiexact is negate iexact, others are similar.
 - neregex
 - neiregex
 
-Exists
-^^^^^^
+Complement
+^^^^^^^^^^
 
-- exists
-- neexists
+- complement
 
 Extra regexes
 ^^^^^^^^^^^^^

--- a/lookup_extensions/__init__.py
+++ b/lookup_extensions/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """UNCOVER TRUTH Inc."""
 __email__ = 'develop@uncovertruth.co.jp'
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 default_app_config = 'lookup_extensions.apps.LookupExtensionsConfig'

--- a/lookup_extensions/lookups/__init__.py
+++ b/lookup_extensions/lookups/__init__.py
@@ -1,3 +1,3 @@
-from .exregex import *  # noqa F401,F403
 from .exists import *  # noqa F401,F403
+from .exregex import *  # noqa F401,F403
 from .negate import *  # noqa F401,F403

--- a/lookup_extensions/lookups/__init__.py
+++ b/lookup_extensions/lookups/__init__.py
@@ -1,2 +1,3 @@
 from .exregex import *  # noqa F401,F403
+from .exists import *  # noqa F401,F403
 from .negate import *  # noqa F401,F403

--- a/lookup_extensions/lookups/exists.py
+++ b/lookup_extensions/lookups/exists.py
@@ -1,0 +1,24 @@
+from django.db.models import Exists
+from django.db.models.fields import Field
+from django.db.models.lookups import (
+    BuiltinLookup,
+    FieldGetDbPrepValueMixin,
+)
+
+
+@Field.register_lookup
+class Complement(FieldGetDbPrepValueMixin, BuiltinLookup):
+    lookup_name = 'complement'
+
+    def process_rhs(self, compiler, connection):
+        if self.rhs_is_direct_value() or not isinstance(self.rhs, Exists):
+            raise ValueError("Exists subqueries are required")
+
+        db_rhs = getattr(self.rhs, '_db', None)
+        if db_rhs is not None and db_rhs != connection.alias:
+            raise ValueError("Subqueries aren't allowed across different databases")
+
+        return super(Complement, self).process_rhs(compiler, connection)
+
+    def as_sql(self, compiler, connection):
+        return self.process_rhs(compiler, connection)

--- a/lookup_extensions/sql.py
+++ b/lookup_extensions/sql.py
@@ -1,20 +1,15 @@
-from django.core.exceptions import FieldError
-from django.db.models import Exists
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.sql import Query as DjangoQuery
 
 
 class ExtendedQueryMixin(object):
     SUBQUERY_LOOKUPS = (
-        'exists',
-        'neexists',
+        'complement',
     )
 
     def build_lookup(self, lookups, lhs, rhs):
         if lookups and lookups[-1] in self.SUBQUERY_LOOKUPS:
-            if not isinstance(rhs, Exists):
-                raise FieldError("Value is not Subquery instance.")
-            return super(ExtendedQueryMixin, self).build_lookup(['exact'], rhs, not lookups[-1].startswith('ne'))
+            return super(ExtendedQueryMixin, self).build_lookup(lookups[-1:], rhs, rhs)
         return super(ExtendedQueryMixin, self).build_lookup(lookups, lhs, rhs)
 
     def prepare_lookup_value(self, value, lookups, can_reuse, allow_joins=True):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,7 +28,6 @@ def runtests():
         interactive=False,
         keepdb=True,
         debug_sql=True,
-        tags=['exists'],
     )
     if os.environ.get('TEST_WITH_REDSHIFT', None) == 'yes':
         test_runner.keepdb = True

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,6 +28,7 @@ def runtests():
         interactive=False,
         keepdb=True,
         debug_sql=True,
+        tags=['exists'],
     )
     if os.environ.get('TEST_WITH_REDSHIFT', None) == 'yes':
         test_runner.keepdb = True

--- a/tests/test_lookup/tests.py
+++ b/tests/test_lookup/tests.py
@@ -10,6 +10,7 @@ from django.db.models import (
     OuterRef,
 )
 from django.test import skipUnlessDBFeature
+from django.test import tag
 
 from utils import skipIfDBVendor
 
@@ -1168,20 +1169,22 @@ class LookupTests(DjangoLookupTests):
             ],
         )
 
-    def test_exists(self):
+    @tag('exists')
+    def test_complement(self):
         tags = Tag.objects.filter(articles=OuterRef('id'), name='Tag 2')
         self.assertQuerysetEqual(
-            Article.objects.filter(tag__exists=Exists(tags)).filter(author=self.au1),
+            Article.objects.filter(tag__complement=Exists(tags)).filter(author=self.au1),
             [
                 '<Article: Article 4>',
                 '<Article: Article 3>',
             ],
         )
 
-    def test_neexists(self):
+    @tag('exists')
+    def test_negate_complement(self):
         tags = Tag.objects.filter(articles=OuterRef('id'), name='Tag 2')
         self.assertQuerysetEqual(
-            Article.objects.filter(tag__neexists=Exists(tags)).filter(author=self.au1),
+            Article.objects.filter(tag__complement=~Exists(tags)).filter(author=self.au1),
             [
                 '<Article: Article 2>',
                 '<Article: Article 1>',

--- a/tests/test_lookup/tests.py
+++ b/tests/test_lookup/tests.py
@@ -10,7 +10,6 @@ from django.db.models import (
     OuterRef,
 )
 from django.test import skipUnlessDBFeature
-from django.test import tag
 
 from utils import skipIfDBVendor
 

--- a/tests/test_lookup/tests.py
+++ b/tests/test_lookup/tests.py
@@ -1169,7 +1169,6 @@ class LookupTests(DjangoLookupTests):
             ],
         )
 
-    @tag('exists')
     def test_complement(self):
         tags = Tag.objects.filter(articles=OuterRef('id'), name='Tag 2')
         self.assertQuerysetEqual(
@@ -1180,7 +1179,6 @@ class LookupTests(DjangoLookupTests):
             ],
         )
 
-    @tag('exists')
     def test_negate_complement(self):
         tags = Tag.objects.filter(articles=OuterRef('id'), name='Tag 2')
         self.assertQuerysetEqual(


### PR DESCRIPTION
- Some hacks for EXISTS/NOT EXISTS filters
- Remove ` = True` from `EXISTS() = True` that broadcast subquery to all nodes in Redshift